### PR TITLE
Use /lang directory for translation files on Laravel 9.x || 10.x and fix redirect url for Tap payment

### DIFF
--- a/src/Classes/TapPayment.php
+++ b/src/Classes/TapPayment.php
@@ -42,52 +42,51 @@ class TapPayment extends BaseController implements PaymentInterface
      */
     public function pay($amount = null, $user_id = null, $user_first_name = null, $user_last_name = null, $user_email = null, $user_phone = null, $source = null)
     {
-        $this->setPassedVariablesToGlobal($amount,$user_id,$user_first_name,$user_last_name,$user_email,$user_phone,$source);
+        $this->setPassedVariablesToGlobal($amount, $user_id, $user_first_name, $user_last_name, $user_email, $user_phone, $source);
 
         $required_fields = ['amount', 'user_first_name', 'user_last_name', 'user_email', 'user_phone'];
-        
+
         $this->checkRequiredFields($required_fields, 'Tap', func_get_args());
 
         $unique_id = uniqid();
         $response = Http::withHeaders([
-            "authorization"=>"Bearer ".$this->tap_secret_key,
-            "content-type"=>"application/json",
-            'lang_code'=>$this->tap_lang_code
-        ])->post('https://api.tap.company/v2/charges',[
-            "amount" => $this->amount, 
-            "currency" => $this->currency, 
-            "threeDSecure" => true, 
-            "save_card" => false, 
-            "description" => "Cerdit", 
-            "statement_descriptor" => "Cerdit", 
+            "authorization" => "Bearer " . $this->tap_secret_key,
+            "content-type" => "application/json",
+            'lang_code' => $this->tap_lang_code
+        ])->post('https://api.tap.company/v2/charges', [
+            "amount" => $this->amount,
+            "currency" => $this->currency,
+            "threeDSecure" => true,
+            "save_card" => false,
+            "description" => "Cerdit",
+            "statement_descriptor" => "Cerdit",
             "reference" => [
-                "transaction" => $unique_id , 
-                "order" => $unique_id 
-            ], 
+                "transaction" => $unique_id,
+                "order" => $unique_id
+            ],
             "receipt" => [
-                "email" => true, 
+                "email" => true,
                 "sms" => true
             ], "customer" => [
-                "first_name" => $this->user_first_name, 
-                "middle_name" => "", 
-                "last_name" => $this->user_last_name, 
-                "email" => $this->user_email, 
+                "first_name" => $this->user_first_name,
+                "middle_name" => "",
+                "last_name" => $this->user_last_name,
+                "email" => $this->user_email,
                 "phone" => [
-                    "country_code" => "20", 
+                    "country_code" => "20",
                     "number" => $this->user_phone
                 ]
-            ], 
-            "source" => ["id" => "src_all"], 
-            "post" => ["url" => $this->verify_route_name], 
-            "redirect" => ["url" => $this->verify_route_name]
+            ],
+            "source" => ["id" => "src_all"],
+            "post" => ["url" => route($this->verify_route_name, ['payment' => "tap"])],
+            "redirect" => ["url" => route($this->verify_route_name, ['payment' => "tap"])]
         ])->json();
-        
-        return [
-            'payment_id'=>$response['id'],
-            'redirect_url'=>$response['transaction']['url'],
-            'html'=>""
-        ];
 
+        return [
+            'payment_id' => $response['id'],
+            'redirect_url' => $response['transaction']['url'],
+            'html' => ""
+        ];
     }
 
     /**
@@ -97,23 +96,22 @@ class TapPayment extends BaseController implements PaymentInterface
     public function verify(Request $request): array
     {
         $response = Http::withHeaders([
-            "authorization"=>"Bearer ".$this->tap_secret_key,
-        ])->get('https://api.tap.company/v2/charges/'.$request->tap_id)->json();
-        if(isset($response['status']) && $response['status']=="CAPTURED"){
+            "authorization" => "Bearer " . $this->tap_secret_key,
+        ])->get('https://api.tap.company/v2/charges/' . $request->tap_id)->json();
+        if (isset($response['status']) && $response['status'] == "CAPTURED") {
             return [
                 'success' => true,
-                'payment_id'=>$request->tap_id,
+                'payment_id' => $request->tap_id,
                 'message' => __('nafezly::messages.PAYMENT_DONE'),
                 'process_data' => $response
             ];
-        }else{
+        } else {
             return [
                 'success' => false,
-                'payment_id'=>$request->tap_id,
+                'payment_id' => $request->tap_id,
                 'message' => __('nafezly::messages.PAYMENT_FAILED'),
                 'process_data' => $response
             ];
         }
-        
     }
 }

--- a/src/NafezlyPaymentsServiceProvider.php
+++ b/src/NafezlyPaymentsServiceProvider.php
@@ -24,21 +24,26 @@ class NafezlyPaymentsServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->configure();
-        $this->registerPublishing();
-        
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'nafezly');
-        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'nafezly');
-        
+
+        $langPath = 'vendor/payments';
+        $langPath = (function_exists('lang_path'))
+            ? lang_path($langPath)
+            : resource_path('lang/' . $langPath);
+
+        $this->registerPublishing($langPath);
+
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'nafezly');
+
+
+
 
         $this->publishes([
-            __DIR__.'/../resources/views' => resource_path('views/vendor/nafezly'),
-        ]);
-        $this->publishes([
+            __DIR__ . '/../resources/views' => resource_path('views/vendor/nafezly'),
             __DIR__ . '/../config/nafezly-payments.php' => config_path('nafezly-payments.php'),
-        ]);
-        $this->publishes([
-            __DIR__ . '/../resources/lang' => resource_path('lang/vendor/payments'),
-        ]);
+            __DIR__ . '/../resources/lang' => $langPath,
+        ], 'nafezly-payments-all');
+
+        $this->registerTranslations($langPath);
     }
 
     /**
@@ -79,7 +84,6 @@ class NafezlyPaymentsServiceProvider extends ServiceProvider
         $this->app->bind(PaytabsPayment::class, function () {
             return new PaytabsPayment();
         });
-        
     }
 
     /**
@@ -90,26 +94,36 @@ class NafezlyPaymentsServiceProvider extends ServiceProvider
     protected function configure()
     {
         $this->mergeConfigFrom(
-            __DIR__ . '/../config/nafezly-payments.php', 'nafezly-payments'
+            __DIR__ . '/../config/nafezly-payments.php',
+            'nafezly-payments'
         );
     }
-
+    /**
+     * Register translations.
+     *
+     * @return void
+     */
+    public function registerTranslations($langPath)
+    {
+        $this->loadTranslationsFrom(__DIR__ . '/../resources/lang', 'nafezly');
+        $this->loadTranslationsFrom($langPath, 'nafezly');
+    }
     /**
      * Register the package's publishable resources.
      *
      * @return void
      */
-    protected function registerPublishing()
+    protected function registerPublishing($langPath)
     {
         $this->publishes([
             __DIR__ . '/../config/nafezly-payments.php' => config_path('nafezly-payments.php'),
         ], 'nafezly-payments-config');
+
         $this->publishes([
-            __DIR__ . '/../resources/lang' => resource_path('lang/vendor/payments'),
+            __DIR__ . '/../resources/lang' => $langPath,
         ], 'nafezly-payments-lang');
         $this->publishes([
             __DIR__ . '/../resources/views' => resource_path('views/vendor/payments'),
         ], 'nafezly-payments-views');
-
     }
 }


### PR DESCRIPTION
Publish the translation files on /lang/vendor directory instead of /resources/lang/vendor for Laravel 9.x
and ***fix redirect url for Tap payment***
