### PR TITLE
Fix Tap (response missing id)

### DIFF
--- a/src/Classes/TapPayment.php
+++ b/src/Classes/TapPayment.php
@@ -82,11 +82,16 @@ class TapPayment extends BaseController implements PaymentInterface
             "redirect" => ["url" => route($this->verify_route_name, ['payment' => "tap"])]
         ])->json();
 
-        return [
-            'payment_id' => $response['id'],
-            'redirect_url' => $response['transaction']['url'],
-            'html' => ""
-        ];
+        try {
+            return [
+                'payment_id' => $response['id'],
+                'redirect_url' => $response['transaction']['url'],
+                'process_data' => $response,
+                'html' => ""
+            ];
+        } catch (\Throwable $th) {
+            return $response;
+        }
     }
 
     /**


### PR DESCRIPTION
## In Tap Payments
This error happens when the response is not in the format you have written
![image](https://github.com/Nafezly/payments/assets/43925829/16b5fcb6-9057-4211-86ef-b76714efb313)

This response format returns when there is an error 
![image](https://github.com/Nafezly/payments/assets/43925829/4e1506fc-8626-4bc6-95f9-7562a8a2bd45)

- Also you need to prevent pass 0 as the $amount