### PR TITLE
refactor: remove unnecessary leading backslash from Http facade calls…

### DIFF
--- a/src/Classes/BinancePayment.php
+++ b/src/Classes/BinancePayment.php
@@ -81,7 +81,7 @@ class BinancePayment extends BaseController implements PaymentInterface
         $binance_pay_key = $this->binance_api;
         $binance_pay_secret = $this->binance_secret;
         $signature = strtoupper(hash_hmac('SHA512',$payload,$binance_pay_secret));
-        $response = \Http::withHeaders([
+        $response = Http::withHeaders([
             "Content-Type"=>"application/json",
             "BinancePay-Timestamp"=>$timestamp,
             "BinancePay-Nonce"=>$nonce,

--- a/src/Classes/ChangellyPayment.php
+++ b/src/Classes/ChangellyPayment.php
@@ -68,7 +68,7 @@ class ChangellyPayment extends BaseController implements PaymentInterface
 
         //dd($key);
 
-        $response = \Http::withHeaders([
+        $response = Http::withHeaders([
             "X-Api-Key" => $this->changelly_api_key,
             'X-Signature'=> $key,
             'Content-type'=>'application/json'

--- a/src/Classes/ClickPayPayment.php
+++ b/src/Classes/ClickPayPayment.php
@@ -60,7 +60,7 @@ class ClickPayPayment extends BaseController implements PaymentInterface
         else
             $unique_id = $this->payment_id;
 
-        $response = \Http::withHeaders([
+        $response = Http::withHeaders([
             'authorization' => $this->clickpay_server_key
         ])->post('https://secure.clickpay.com.sa/payment/request', [
             "profile_id" => $this->clickpay_profile_id,
@@ -125,7 +125,7 @@ class ClickPayPayment extends BaseController implements PaymentInterface
     public function verify(Request $request)
     {
 
-        $response = \Http::withHeaders([
+        $response = Http::withHeaders([
             'authorization' => $this->clickpay_server_key
         ])->post('https://secure.clickpay.com.sa/payment/query', [
             'profile_id' => $this->clickpay_profile_id,

--- a/src/Classes/MamoPayment.php
+++ b/src/Classes/MamoPayment.php
@@ -62,7 +62,7 @@ class MamoPayment extends BaseController implements PaymentInterface
         ];
 
         try{
-            $response = \Http::withToken($this->mamopayment_api_key)
+            $response = Http::withToken($this->mamopayment_api_key)
             ->post($this->mamopayment_base_url."/manage_api/v1/links",$payload);
             if ($response->failed()) {
                 return [
@@ -111,7 +111,7 @@ class MamoPayment extends BaseController implements PaymentInterface
         $payment_id = cache('mamo_payment_'.$request['payment_id']);
 
         if(isset($payment_id)){
-            $response = \Http::withToken($this->mamopayment_api_key)
+            $response = Http::withToken($this->mamopayment_api_key)
                 ->get($this->mamopayment_base_url."/manage_api/v1/links/".$payment_id);
             if ($response->failed()) {
                 return [

--- a/src/Classes/NowPaymentsInvoicePayment.php
+++ b/src/Classes/NowPaymentsInvoicePayment.php
@@ -77,7 +77,7 @@ class NowPaymentsInvoicePayment extends BaseController implements PaymentInterfa
     {
         $invoice_id = $request->NP_id??$request->payment_id;
         
-        $response = \Http::withHeaders([
+        $response = Http::withHeaders([
             'x-api-key'=>$this->nowpayments_api_key
         ])->get('https://api.nowpayments.io/v1/invoice/'.$invoice_id)->json();
 

--- a/src/Classes/NowPaymentsPayment.php
+++ b/src/Classes/NowPaymentsPayment.php
@@ -82,7 +82,7 @@ class NowPaymentsPayment extends BaseController implements PaymentInterface
     public function verify(Request $request)
     {
         $payment_id = $request->NP_id??$request->payment_id;
-        $response = \Http::withHeaders([
+        $response = Http::withHeaders([
             'x-api-key'=>$this->nowpayments_api_key
         ])->get('https://api.nowpayments.io/v1/payment/'.$payment_id)->json();
 
@@ -104,7 +104,7 @@ class NowPaymentsPayment extends BaseController implements PaymentInterface
     }
     public function get_minimum_amount($from,$to,$fiat_equivalent="usd"){
         try{
-            $response = \Http::withHeaders(['x-api-key'=>$this->nowpayments_api_key])->get('https://api.nowpayments.io/v1/min-amount?currency_from='.$from.'&currency_to='.$to.'&fiat_equivalent='.$fiat_equivalent)->json();
+            $response = Http::withHeaders(['x-api-key'=>$this->nowpayments_api_key])->get('https://api.nowpayments.io/v1/min-amount?currency_from='.$from.'&currency_to='.$to.'&fiat_equivalent='.$fiat_equivalent)->json();
             return $response['fiat_equivalent'];
         }catch(\Exception $e){
             return 10000000;

--- a/src/Classes/OneLatPayment.php
+++ b/src/Classes/OneLatPayment.php
@@ -42,7 +42,7 @@ class OneLatPayment extends BaseController implements PaymentInterface
 
         
         try{
-            $payment_methods = \Http::withHeaders([
+            $payment_methods = Http::withHeaders([
                 'x-api-key' => $this->onelat_key,
                 'x-api-secret' => $this->onelat_secret,
                 'Content-Type' => 'application/json',
@@ -51,7 +51,7 @@ class OneLatPayment extends BaseController implements PaymentInterface
                 if(null !== collect($payment_methods['payment_methods'])->where('type','CARD')->where('currency','USD')->first() ){
                     $method = collect($payment_methods['payment_methods'])->where('type','CARD')->where('currency','USD')->first();
 
-                    $response = \Http::withHeaders([
+                    $response = Http::withHeaders([
                         'x-api-key' => $this->onelat_key,
                         'x-api-secret' => $this->onelat_secret,
                         'Content-Type' => 'application/json',

--- a/src/Classes/PayPalCreditPayment.php
+++ b/src/Classes/PayPalCreditPayment.php
@@ -74,7 +74,7 @@ class PayPalCreditPayment extends BaseController implements PaymentInterface
             'countryCode'=>""
         ];
         try{
-            $fetch_address = \Http::get('http://ip-api.com/json/'.$this->get_ip())->json();
+            $fetch_address = Http::get('http://ip-api.com/json/'.$this->get_ip())->json();
             if(is_array($fetch_address))
                 $country = array_replace_recursive($country,$fetch_address);
         }catch(\Exception $e){}
@@ -242,7 +242,7 @@ class PayPalCreditPayment extends BaseController implements PaymentInterface
         else
             $ipaddress = 'UNKNOWN';
         if($ipaddress=="127.0.0.1"){
-            $ip = \Http::get('https://api.ipify.org/?format=json')->json();
+            $ip = Http::get('https://api.ipify.org/?format=json')->json();
             return $ip['ip'];
         }
         return $ipaddress;

--- a/src/Classes/PaycecPayment.php
+++ b/src/Classes/PaycecPayment.php
@@ -60,7 +60,7 @@ class PaycecPayment extends BaseController implements PaymentInterface
 
         try{
 
-            $country = \Http::get('http://ip-api.com/json/'.$this->get_ip())->json();
+            $country = Http::get('http://ip-api.com/json/'.$this->get_ip())->json();
             $params =  [
                 'merchantName' => $this->paycec_merchant_username,
                 'merchantSecretKey' => $this->paycec_merchant_secret,
@@ -180,7 +180,7 @@ class PaycecPayment extends BaseController implements PaymentInterface
         else
             $ipaddress = 'UNKNOWN';
         if($ipaddress=="127.0.0.1"){
-            $ip = \Http::get('https://api.ipify.org/?format=json')->json();
+            $ip = Http::get('https://api.ipify.org/?format=json')->json();
             return $ip['ip'];
         }
         return $ipaddress;

--- a/src/Classes/PaylinkPayment.php
+++ b/src/Classes/PaylinkPayment.php
@@ -51,13 +51,13 @@ class PaylinkPayment extends BaseController implements PaymentInterface
         else
             $payment_id = $this->payment_id;
 
-        $get_token_id = \Http::post($url."/api/auth",[
+        $get_token_id = Http::post($url."/api/auth",[
             'apiId'=>$this->paylink_app_id,
             'secretKey'=>$this->paylink_api_key,
             'persistToken'=>false
         ])->json();
         if(isset($get_token_id['id_token'])){
-            $response = \Http::withHeaders([
+            $response = Http::withHeaders([
                 'Authorization'=>"Bearer ".$get_token_id['id_token'],
                 'Content-Type'=>"application/JSON",
             ])->post($url."/api/addInvoice",[
@@ -104,13 +104,13 @@ class PaylinkPayment extends BaseController implements PaymentInterface
             $url = "https://restpilot.paylink.sa";
 
         $payment_id = uniqid().rand(10000,99999);
-        $get_token_id = \Http::post($url."/api/auth",[
+        $get_token_id = Http::post($url."/api/auth",[
             'apiId'=>$this->paylink_app_id,
             'secretKey'=>$this->paylink_api_key,
             'persistToken'=>false
         ])->json();
         if(isset($get_token_id['id_token'])){
-            $response = \Http::withHeaders([
+            $response = Http::withHeaders([
                 'Authorization'=>"Bearer ".$get_token_id['id_token'],
                 'Content-Type'=>"application/json",
             ])->get($url."/api/getInvoice/".$request['transactionNo'])->json();

--- a/src/Classes/PaymobPayment.php
+++ b/src/Classes/PaymobPayment.php
@@ -58,7 +58,7 @@ class PaymobPayment extends BaseController implements PaymentInterface
         else
             $unique_id = $this->payment_id;
 
-        $res = \Http::withHeaders([
+        $res = Http::withHeaders([
             'Authorization'=>"Token ".$this->paymob_secret_key,
         ])->post('https://accept.paymob.com/v1/intention/',[
             'amount'=>$this->amount*100,

--- a/src/Classes/PayopPayment.php
+++ b/src/Classes/PayopPayment.php
@@ -89,7 +89,7 @@ class PayopPayment extends BaseController implements PaymentInterface
             "failPath" => route($this->verify_route_name,['payment'=>"payop",'payment_id'=>$unique_id]),
         ];
  
-        $response = \Http::withHeaders([
+        $response = Http::withHeaders([
             'Content-Type' => 'application/json',
         ])->post('https://api.payop.com/v1/invoices/create', $payload);
         $json_response = $response->json();
@@ -130,7 +130,7 @@ class PayopPayment extends BaseController implements PaymentInterface
         }
 
         if($invoice_id != ""){
-            $response = \Http::get('https://api.payop.com/v1/invoices/'.$invoice_id);
+            $response = Http::get('https://api.payop.com/v1/invoices/'.$invoice_id);
             $response_json = $response->json();
             if(isset($response_json['data']['status']) && in_array($response_json['data']['status'], ['success','paid'])){
                 return [

--- a/src/Classes/PrimePayment.php
+++ b/src/Classes/PrimePayment.php
@@ -79,7 +79,7 @@ class PrimePayment extends BaseController implements PaymentInterface
         $secret1 = $this->prime_secret_word_1;
         $data['sign'] =md5($secret1.$data['action'].$data['project'].$data['sum'].$data['currency'].$data['innerID'].$data['email'].$data['payWay']);
 
-        $response = \Http::asForm()->post('https://pay.primepayments.io/API/v2/',$data)->json();
+        $response = Http::asForm()->post('https://pay.primepayments.io/API/v2/',$data)->json();
         dd($response);
 
 

--- a/src/Classes/WisePayment.php
+++ b/src/Classes/WisePayment.php
@@ -53,7 +53,7 @@ class WisePayment extends BaseController implements PaymentInterface
             if(is_array($this->source))
                 $selectedPaymentMethods_init=$this->source;
         
-            $init = \Http::withHeaders([
+            $init = Http::withHeaders([
                 'Cookie'=>"oauthToken=".$this->wise_api_key,
                 'Authorization'=>"Bearer ".$this->wise_api_key
             ])->get('https://wise.com/gateway/v3/profiles/'.$this->wise_profile_id.'/acquiring/payment-methods', [
@@ -67,7 +67,7 @@ class WisePayment extends BaseController implements PaymentInterface
                 if(in_array($check_available_method,collect($init->json()['content'])->where('available',true)->pluck('paymentMethodType')->toArray()))
                     $available_payment_methods[]=$check_available_method;
 
-            $create_payment = \Http::withHeaders([
+            $create_payment = Http::withHeaders([
                 'Host' => 'wise.com',
                 'User-Agent' => 'Mozilla/5.0 (X11; Linux x86_64; rv:108.0) Gecko/20100101 Firefox/108.0',
                 'Accept' => 'application/json, text/plain, */*',
@@ -94,7 +94,7 @@ class WisePayment extends BaseController implements PaymentInterface
                 'selectedPaymentMethods' => $available_payment_methods,
             ]);
             $create_payment_response = $create_payment->json();
-            $publish_payment_response = \Http::withHeaders([
+            $publish_payment_response = Http::withHeaders([
                 'Host' => 'wise.com',
                 'User-Agent' => 'Mozilla/5.0 (X11; Linux x86_64; rv:108.0) Gecko/20100101 Firefox/108.0',
                 'Accept' => 'application/json, text/plain, */*',

--- a/src/Classes/YallaPayPayment.php
+++ b/src/Classes/YallaPayPayment.php
@@ -106,7 +106,7 @@ class YallaPayPayment extends BaseController implements PaymentInterface
             }
         }elseif(isset($request['trx_id'])){
 
-            $res = \Http::post('https://yallapay.net/api/transaction/verify',[
+            $res = Http::post('https://yallapay.net/api/transaction/verify',[
                 'private_key'=>$this->yallapay_secret_key,
                 'trx_id'=>  $payment_id
             ]);


### PR DESCRIPTION
… in payment classes

Problem:
Several gateway classes were using \\Http:: with a leading backslash, while the same files already imported the facade via
'use Illuminate\Support\Facades\Http;'. This is inconsistent and redundant.

Impact on non-Laravel frameworks:
The leading backslash forces PHP to resolve \Http in the global namespace, which breaks usage in environments (e.g. WordPress, Symfony, CodeIgniter) that register Illuminate\Support\Facades\Http but do NOT alias it globally as \Http.

Changes:
- Replaced all \\Http:: occurrences with Http:: in 15 gateway files.
- All affected files already have the proper 'use' import, so this is a zero-breaking change for existing Laravel users.

Benefits:
- Improves code consistency within the codebase.
- Increases portability to non-Laravel frameworks.
- Reduces dependency on global class aliases.